### PR TITLE
Update FITARA Milestones

### DIFF
--- a/schemaexamples/FITARAmilestones_schema.json
+++ b/schemaexamples/FITARAmilestones_schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-04/schema#",
-	"version": "April 2016 (v1)",
+	"version": "August 2016 (v1.1)",
 	"id": "https://management.cio.gov/schema",
 	"name": "/",
 	"title": "FITARA Milestones",
@@ -54,17 +54,17 @@
 					"dcoiArea": {
 						"type": "string",
 						"enum": ["optimization", "closures", "costSavings", "sharedServices", "cloudMigration", "CIOLeadership", "other", "nonDataCenter"]
-					},
-					"required": [
-						"milestoneID",
-						"milestoneDesc",
-						"milestoneTargetCompletionDate",
-						"milestoneStatus",
-						"milestoneStatusDesc",
-						"commonBaselineArea",
-						"dcoiArea"
-					]
-				}
+					}
+				},
+				"required": [
+					"milestoneID",
+					"milestoneDesc",
+					"milestoneTargetCompletionDate",
+					"milestoneStatus",
+					"milestoneStatusDesc",
+					"commonBaselineArea",
+					"dcoiArea"
+				]
 			}
 		}
 	}


### PR DESCRIPTION
The new schema file was giving errors for validating the August 30 deliverable. The **required** element was nested within the **items**  element.   This change pulls out the **required** element.  Quick test against http://jsonschemalint.com/draft5/#  will show errors in old file.
